### PR TITLE
Skip webhooks that don't belong to this specific site Fixes #570

### DIFF
--- a/docs/api-collection/moysklad.yml
+++ b/docs/api-collection/moysklad.yml
@@ -1,0 +1,72 @@
+opencollection: 1.0.0
+info:
+  name: moysklad
+config:
+  proxy:
+    inherit: true
+    config:
+      protocol: http
+      hostname: ''
+      port: ''
+      auth:
+        username: ''
+        password: ''
+      bypassProxy: ''
+items:
+  - info:
+      name: update webhook
+      type: http
+      seq: 1
+    http:
+      method: POST
+      url: '{{base_url}}/entity/webhook?url=https://wooms-other-app.com/webhook&action=UPDATE&entityType=customerorder'
+      headers:
+        - name: Content-Type
+          value: application/json
+      params:
+        - name: url
+          value: https://wooms-other-app.com/webhook
+          type: query
+        - name: action
+          value: UPDATE
+          type: query
+        - name: entityType
+          value: customerorder
+          type: query
+      auth:
+        type: basic
+        username: '{{login}}'
+        password: '{{password}}'
+    settings:
+      encodeUrl: true
+      timeout: 0
+      followRedirects: true
+      maxRedirects: 5
+  - info:
+      name: get webhooks
+      type: http
+      seq: 2
+    http:
+      method: GET
+      url: '{{base_url}}/entity/webhook'
+      auth:
+        type: basic
+        username: '{{login}}'
+        password: '{{password}}'
+    settings:
+      encodeUrl: true
+      timeout: 0
+      followRedirects: true
+      maxRedirects: 5
+  - info:
+      name: moysklad
+      type: script
+    script: ''
+bundled: true
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git
+    exportedAt: '2026-04-30T15:40:09.953Z'
+    exportedUsing: Bruno

--- a/includes/OrderUpdateFromMoySklad.php
+++ b/includes/OrderUpdateFromMoySklad.php
@@ -583,6 +583,11 @@ class OrderUpdateFromMoySklad
                     continue;
                 }
 
+				// Skip webhooks that don't belong to this specific site
+				if ($row['url'] !== rest_url('/wooms/v1/order-update/')) {
+					continue;
+				}
+
                 $webhooks[$row['id']] = array(
                     'entityType' => $row['entityType'],
                     'url'        => $row['url'],

--- a/tests/data/fixtures-v1/webhook/webhook.json
+++ b/tests/data/fixtures-v1/webhook/webhook.json
@@ -1,0 +1,21 @@
+{
+  "context" : {
+    "employee" : {
+      "meta" : {
+        "href" : "https://api.moysklad.ru/api/remap/1.2/context/employee",
+        "metadataHref" : "https://api.moysklad.ru/api/remap/1.2/entity/employee/metadata",
+        "type" : "employee",
+        "mediaType" : "application/json"
+      }
+    }
+  },
+  "meta" : {
+    "href" : "https://api.moysklad.ru/api/remap/1.2/entity/webhook",
+    "type" : "webhook",
+    "mediaType" : "application/json",
+    "size" : 0,
+    "limit" : 1000,
+    "offset" : 0
+  },
+  "rows" : [ ]
+}


### PR DESCRIPTION
## Какие проблемы решаем? Что есть?

- [x] В текущей версии плагин WooMS проявляет избыточную «агрессивность» при управлении вебхуками в МойСклад. При каждом посещении страницы настроек срабатывает проверка check_webhooks_and_try_fix().

Если опция «Передатчик статуса: МойСклад > Сайт» отключена, плагин запрашивает список всех хуков сущности customerorder и удаляет их по ID, не проверяя URL. Это приводит к тому, что WooMS удаляет вебхуки сторонних сервисов (интеграции с маркетплейсами, службы уведомлений и т.д.), что парализует работу других приложений в экосистеме МойСклад.

## Как надо? Как это должно работать? Как это будет?

- [x] Валидация URL: В метод check_webhooks_and_try_fix добавлена строгая проверка URL вебхука. Теперь плагин учитывает и удаляет только те хуки, адрес которых совпадает с REST API текущего сайта: rest_url('/wooms/v1/order-update/').
- [x] Безопасность сторонних данных: Все сторонние вебхуки, не принадлежащие текущей инсталляции WooMS, теперь игнорируются и остаются нетронутыми.
- [x] Оптимизация: Добавлен пропуск (skip) для хуков других сущностей на раннем этапе цикла, что снижает нагрузку при обработке ответа API.

## Чек лист

- [x] Fixes #570 
- [ ] тест на стенде https://wooms.wpcraft.ru/
- [ ] В changelog добавлено описание изменений
